### PR TITLE
Dimensionful curves, etc.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ julia = "1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Unitful"]

--- a/src/bnb.jl
+++ b/src/bnb.jl
@@ -107,7 +107,7 @@ function collision_detection(a, b; atol=1e-8)
     leaves, glb, gub, soln = _init(a, b)
     while gub > atol
         glb, gub, soln = _loop(a, b, leaves, glb, gub)
-        if glb > 0
+        if glb > zero(glb)
             return false
         end
     end

--- a/src/bounds.jl
+++ b/src/bounds.jl
@@ -38,12 +38,12 @@ function cvxhull(b::Curve{2, T}, β::Interval) where {T}
     center = (fA + fB)/2.0
     fdist = norm(fA - fB)
     rotate = SMatrix{2,2}(1.0I)
-    if fdist > 0.0
+    if fdist > zero(fdist)
         dir = (fB-fA)/fdist
         rotate = SMatrix{2,2}(dir[1],dir[2],-dir[2],dir[1])
     end
     a = arclength(b, β)/2.0
-    if (a - fdist/2.0) > eps(T)
+    if (a - fdist/2.0) > eps(T)*oneunit(T)
         b = sqrt(a^2 - (fdist/2)^2)
         octagon = SVector{8}(
                    SVector{2}(a*(√2 - 1), b),
@@ -67,7 +67,7 @@ function cvxhull(b::Curve{3, T}, β::Interval) where {T}
     center = (fA + fB)/2.0
     fdist = norm(fA - fB)
     rotate = SMatrix{3,3}(1.0I)
-    if fdist > 0.0
+    if fdist > zero(fdist)
         dir = (fB-fA)/fdist
         aux = SVector{3}(1.0, 0.0, 0.0)
         aux = abs(dir'*aux) < 0.99 ? aux : SVector{3}(0.0, 1.0, 0.0)
@@ -75,7 +75,7 @@ function cvxhull(b::Curve{3, T}, β::Interval) where {T}
         rotate = hcat(dir, aux, auxperp)
     end
     a = arclength(b, β)/2.0
-    if (a - fdist/2.0) > eps(T)
+    if (a - fdist/2.0) > eps(T)*oneunit(T)
         b = sqrt(a^2 - (fdist/2)^2)
         tetradecahedron = SVector{16}(
                    SVector{3}( a,  b*(√2 - 1),  b*(√2 - 1)),

--- a/src/curves/bernstein.jl
+++ b/src/curves/bernstein.jl
@@ -207,7 +207,7 @@ end
 Base.eltype(::Type{Bernstein{D, N, T}}) where {D, N, T} = T
 Base.getindex(b::Bernstein, j::Int) = b.f.control_points[j]
 
-function Base.show(io::IO, b::Bernstein{D, N, T}) where {D, N, T}
+function Base.show(io::IO, b::Bernstein{D, N}) where {D, N}
     ordind = (N-1)%10 == 1 ? "st" : "th"
     ordind = (N-1)%10 == 2 ? "nd" : ordind
     ordind = (N-1)%10 == 3 ? "rd" : ordind

--- a/src/curves/bernstein.jl
+++ b/src/curves/bernstein.jl
@@ -141,7 +141,7 @@ end
     nck = _binomial(b)
 
     for k = 1:2N-1
-        exprs[k] = :(zero($T))
+        exprs[k] = :(zero($T)*zero($T))
         den = (k==1) ? :(one($T)) : :($den*$(2N-k)/$(k-1))
         for j = max(1, k-N+1):min(N, k)
             exprs[k] = :($(exprs[k]) + $(nck[j])*$(nck[k-j+1])*b[$j]'*b[$(k-j+1)])
@@ -188,18 +188,18 @@ end
 function arclength(b::Bernstein, t::Real)
     t = scalet(b, t)
     s = b.s(t)
-    s > 0 ? sqrt(t*s) : 0.0
+    s > zero(s) ? sqrt(t*s) : float(zero(eltype(b)))
 end
 
 function arclength(b::Bernstein, θ::Interval)
     θ = scalet(b, θ)
     s = b.s(θ.hi) - b.s(θ.lo)
-    s > 0 ? sqrt(diam(θ)*s) : 0.0
+    s > zero(s) ? sqrt(diam(θ)*s) : float(zero(eltype(b)))
 end
 
 function arclength(b::Bernstein)
     s = b.s(1.0)
-    s > 0 ? sqrt(s) : 0.0
+    s > zero(s) ? sqrt(s) : float(zero(eltype(b)))
 end
 
 Base.eltype(::Type{<:Bernstein{D, N, M, T}}) where {D, N, M, T} = T

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,11 +18,11 @@ import CurveProximityQueries: differentiate, integrate
         @test_broken eltype(Bernstein([[0, 0], [1, 1]])) <: Float64
 
         # none of the following should error; some should be inferrable
-        @test_broken Bernstein([
+        @test Bernstein([
                 @SVector([0.0, 0.0]),
                 @SVector([1.0, 1.0])
             ])(0.5) === @SVector([0.5, 0.5])
-        @test_broken @inferred(Bernstein(@SVector([
+        @test @inferred(Bernstein(@SVector([
                 @SVector([0.0, 0.0]),
                 @SVector([1.0, 1.0])
             ])))(0.5) === @SVector([0.5, 0.5])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,28 @@ using Random: seed!
 import CurveProximityQueries: differentiate, integrate
 
 @testset "CurveProximityQueries" begin
+    @testset "Constructors" begin
+        # should return SVector when constructed without SVectors
+        @test Bernstein([[0.0, 0.0], [1.0, 1.0]])(0.5) === @SVector([0.5, 0.5])
+
+        # non-floats arguments should become floats to satisfy assumptions
+        # elsewhere in the code (e.g. use of `eps(T)`)
+        @test_broken eltype(Bernstein([[0, 0], [1, 1]])) <: Float64
+
+        # none of the following should error; some should be inferrable
+        @test_broken Bernstein([
+                @SVector([0.0, 0.0]),
+                @SVector([1.0, 1.0])
+            ])(0.5) === @SVector([0.5, 0.5])
+        @test_broken @inferred(Bernstein(@SVector([
+                @SVector([0.0, 0.0]),
+                @SVector([1.0, 1.0])
+            ])))(0.5) === @SVector([0.5, 0.5])
+        @test @inferred(Bernstein(
+                @SVector([0.0, 0.0]),
+                @SVector([1.0, 1.0])
+            ))(0.5) === @SVector([0.5, 0.5])
+    end
     @testset "Bernstein Polynomials" begin
         B2 = rand(Bernstein{2,8})
         B3 = rand(Bernstein{3,5})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using LinearAlgebra
 using StaticArrays
 using IntervalArithmetic
 using Random: seed!
+using Unitful: nm, μm, mm
 
 import CurveProximityQueries: differentiate, integrate
 
@@ -96,5 +97,15 @@ import CurveProximityQueries: differentiate, integrate
         @test tolerance_verification(c, d, 0.1) == true
         @test tolerance_verification(c, d, 0.3) == false
         @test collision_detection(c, d) == false
+    end
+    @testset "Dimensionful curves" begin
+        b2 = Bernstein([[0.0, 1.0]μm, [1.0, 1.0]μm, [1.0, 0.0]μm])
+        @test b2(0.0) == [0, 1000]nm
+        @test b2(1.0) == [0.001, 0]mm
+        @test arclength(b2) == arclength(Bernstein([[0,1], [1,1], [1,0]])) * μm
+        @test length(CurveProximityQueries.cvxhull(b2, Interval(0.0, 1.0))) == 8
+
+        b3 = Bernstein([[0.0, 0.0, 0.0]mm, [1.0, 0.0, 0.0]mm, [1.0, 0.0, 1.0]mm])
+        @test length(CurveProximityQueries.cvxhull(b3, Interval(0.0, 1.0))) == 16
     end
 end


### PR DESCRIPTION
Thank you for the nice package! This PR is a bit of a grab bag but the commits are pretty well factored. I can split out some of this into separate PRs if you prefer.

I think the first three commits are probably not controversial; mainly they simplify some constructors, while the added tests ensure that with these simplifications, the types created by the constructors remain inferrable to the compiler. (Some of the constructor variants will never be inferrable.)

The fourth commit allows generic `StaticVector` types to be used as points in your Bernstein types. I wanted to do this because I have a `Point <: StaticArrays.FieldVector` type defined elsewhere, with named `x` and `y` fields.

Finally, the fifth commit makes the code in this package almost entirely dimensionally-aware. I wanted to have curves in a 2D space with length dimensions, and I can do that now using Unitful.jl without adding it as a dependency here. I added it as a test-only dependency just so that you can see that it works. The caveat is that one of your dependencies, IntervalArithmetic, does not seem to support dimensionful numbers, so at present the support I've added is limited to evaluating curves or calculating convex hulls. Also, I wasn't sure what to use for dimensionally correct default `atol` arguments, so I have left those alone. But otherwise, if IntervalArithmetic were updated, I don't think you'd have to change anything else in your package for it to just work.