### PR TITLE
Loosen `support` method argument types...

### DIFF
--- a/src/bounds.jl
+++ b/src/bounds.jl
@@ -27,10 +27,14 @@ function getbounds(a, b, θ...)
 end
 
 import ConvexBodyProximityQueries: support
-support(pt::SVector{D}, dir::SVector{D}) where {D} = pt
-function support(vertices::SVector{N, SVector{D, T}}, dir::SVector{D}) where {D, N, T}
-    @inbounds vertices[argmax(Ref(dir').*vertices)]
-end
+support(pt::StaticVector{D}, dir::StaticVector{D}) where {D} = pt
+# the following two methods are both needed for method ambiguity resolution
+# given the method defined above, but both should do the same thing.
+support(vertices::SVector{N, <:StaticVector{D, T}}, dir::StaticVector{D}) where {D, N, T} =
+    _support(vertices, dir)
+support(vertices::SVector{D, <:StaticVector{D, T}}, dir::StaticVector{D}) where {D, T} =
+    _support(vertices, dir)
+_support(vertices, dir) = @inbounds vertices[argmax(Ref(dir').*vertices)]
 
 function cvxhull(b::Curve{2, T}, β::Interval) where {T}
     fA = b(β.lo)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,13 +113,17 @@ import CurveProximityQueries: differentiate, integrate
         @test collision_detection(b3, c3, atol=1e-8mm) == false
     end
     @testset "Support" begin
-        @test_broken CurveProximityQueries.support(Point(1.0, 2.0), Point(1.0, 1.0)) ===
+        @test CurveProximityQueries.support(Point(1.0, 2.0), Point(1.0, 1.0)) ===
             Point(1.0, 2.0)
-        @test_broken CurveProximityQueries.support(@SVector(
+        @test CurveProximityQueries.support(@SVector(
             [Point(0.0, 1.0), Point(1.0, 2.0)]), @SVector([1.0, 1.0])) ===
                 Point(1.0, 2.0)
         @test CurveProximityQueries.support(@SVector(
             [@SVector([0.0, 1.0]), @SVector([1.0, 2.0])]),
                 @SVector([1.0, 1.0])) === @SVector([1.0, 2.0])
+        @test CurveProximityQueries.support(@SVector(
+            [Point(0.0, 1.0), Point(1.0, 2.0), Point(3.0, 4.0)]), Point(1.0, 1.0)) ===
+                Point(3.0, 4.0)
+
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,4 +112,14 @@ import CurveProximityQueries: differentiate, integrate
         @test tolerance_verification(b3, c3, 2cm, atol=1e-8mm) == true
         @test collision_detection(b3, c3, atol=1e-8mm) == false
     end
+    @testset "Support" begin
+        @test_broken CurveProximityQueries.support(Point(1.0, 2.0), Point(1.0, 1.0)) ===
+            Point(1.0, 2.0)
+        @test_broken CurveProximityQueries.support(@SVector(
+            [Point(0.0, 1.0), Point(1.0, 2.0)]), @SVector([1.0, 1.0])) ===
+                Point(1.0, 2.0)
+        @test CurveProximityQueries.support(@SVector(
+            [@SVector([0.0, 1.0]), @SVector([1.0, 2.0])]),
+                @SVector([1.0, 1.0])) === @SVector([1.0, 2.0])
+    end
 end


### PR DESCRIPTION
... to accommodate `StaticVector`s other than `SVector`.

This is a pretty minor change, but in combination with a PR I'll submit to ConvexBodyProximityQueries.jl, it will enable things like:

```
julia> c1 = Bernstein([Point(0,1)μm, Point(1,2)μm])
a 1st order Bernstein polynomial with control points at:
((0.0 μm,1.0 μm), (1.0 μm,2.0 μm))
with an arclength of 1.4142135623730951 μm

julia> c2 = Bernstein([Point(0,0)μm, Point(1,-1)μm])
a 1st order Bernstein polynomial with control points at:
((0.0 μm,0.0 μm), (1.0 μm,-1.0 μm))
with an arclength of 1.4142135623730951 μm

julia> minimum_distance(c1,c2; atol=1e-8μm)
1.0 μm
```

where `Point` is as defined in the tests.