### PR TITLE
wip: Compatibility in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ ConvexBodyProximityQueries = "0.1"
 DataStructures = "0.15"
 IntervalArithmetic = "0.15"
 RecipesBase = "0.6"
-StaticArrays = "0.10"
+StaticArrays = "0.10, 0.11"
 julia = "1.1"
 
 [extras]


### PR DESCRIPTION
I split this out into a separate PR because I wasn't sure if this was an intentional decision on your part, but I wanted to suggest removing the upper limits on dependency versions. ~I think as written before this PR, the syntax implies the exact versions are required.~ edit: it does not. Some minor explanations:

- ~I believe the caret `^` I added in front of the Julia version just means your package will be permitted to work with any version of Julia ≥ 1.0 and < 2.0, when Julia is next allowed to make breaking changes.~ edit: this is already the default behavior
- ~It would at least be nice to loosen the bound on ConvexBodyProximityQueries, if not `≥ 0.1` as I've done below then `^0.1` so that versions up to `0.2` are available.~ edit: this is already the default behavior
- The other packages are pretty well developed but still not declared as 1.0; it is possible changes made there could cause problems here, but if it happens, you can make a PR to `JuliaRegistries/General` to retroactively upper-bound the compatibility.

I made this PR because I had some conflict where I couldn't add your package the first time I tried it; another package I was using in the same environment wanted StaticArrays v0.11.